### PR TITLE
Add link to join Slack

### DIFF
--- a/static/reference-implementation.html
+++ b/static/reference-implementation.html
@@ -213,6 +213,7 @@
             </a><br>     <br> 
 
             <strong class="fw-semibold">Architectural Discussion:</strong> <br>
+            <a href="https://join.slack.com/t/sdvworkinggroup/shared_invite/zt-3c5ied1nk-Mk87s4kOX7ipcNo_VktlWg" class="read-more btn btn-primary main-primary" target="_blank">Join SDV's slack workspace</a> and jump to 
               <a  href="https://sdvworkinggroup.slack.com/archives/C083Z4VL90B" class="read-more btn btn-primary main-primary" target="_blank"
                   >#score-project-channel-public 
                 


### PR DESCRIPTION
Without joining Slack first, the second link to join #score-project-channel-public does not work, and also does not give an indication how it can be fixed. This is very confusing for newcomers, for whom this site is meant primarily.

Closes #20 