### PR TITLE
Add SDV event collection component

### DIFF
--- a/content/articles.md
+++ b/content/articles.md
@@ -57,6 +57,11 @@ breadcrumb_html: |
           <div class="row w-100 g-4">
             <div class="col-12 col-xl-8 gap-3 mt-0">
               <div class="d-flex flex-column gap-3">
+              <efsc-collection pagesize="2" autoscroll="true">
+                  <efsc-event-filters></efsc-event-filters>
+                  <efsc-event-list publishtarget="sdv"></efsc-event-list>
+                  <efsc-pagination maxvisible="5" justify="center"></efsc-pagination>
+                </efsc-collection>
 <!-- ========== START: S-CORE 0.7.0 Release Card (English Version) ========== -->
 <div class="main-blog-item-card d-flex flex-column gap-3">
   <div class="blog-item-content">

--- a/content/articles.md
+++ b/content/articles.md
@@ -55,13 +55,14 @@ breadcrumb_html: |
       >
         <div class="container">
           <div class="row w-100 g-4">
-            <div class="col-12 col-xl-8 gap-3 mt-0">
-              <div class="d-flex flex-column gap-3">
-              <efsc-collection pagesize="2" autoscroll="true">
+          <efsc-collection pagesize="2" autoscroll="true">
                   <efsc-event-filters></efsc-event-filters>
                   <efsc-event-list publishtarget="sdv"></efsc-event-list>
                   <efsc-pagination maxvisible="5" justify="center"></efsc-pagination>
                 </efsc-collection>
+            <div class="col-12 col-xl-8 gap-3 mt-0">
+              <div class="d-flex flex-column gap-3">
+              
 <!-- ========== START: S-CORE 0.7.0 Release Card (English Version) ========== -->
 <div class="main-blog-item-card d-flex flex-column gap-3">
   <div class="blog-item-content">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,6 +27,16 @@
         <link rel="stylesheet" href="{{ . }}" />
       {{ end }}
     {{ end }}
+
+    <link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@eclipsefdn/solstice-components@0.9.0/themes/default-light.css"
+      integrity="sha384-Xg/ri5XEgSYZlqJRcmQJzCub0N7nQkWT94OeblqD+gK7ooiZvTJOgkC5GhvhBD/P"
+      crossorigin="anonymous">
+
+    <script type="module"
+      src="https://cdn.jsdelivr.net/npm/@eclipsefdn/solstice-components@0.9.0/dist-cdn/solstice-components.loader.js"
+      integrity="sha384-UcWSQMj1c1b1VRiaHycuVGCSJ7ltwyF88VcYGthnJauU0cyXHJXhPWBuMA5vHM/a"
+      crossorigin="anonymous"></script>
   </head>
   <body>
     {{ block "main" . }}{{ end }}


### PR DESCRIPTION
It will show all SDV Events: https://www.eclipse.org/events/#events-feed

This pull request introduces the Eclipse Foundation Solstice web components into the project and updates the `articles.md` page to utilize these new components for event filtering and listing. The main changes focus on integrating the Solstice component library and enhancing the articles page with dynamic event-related features.

**Integration of Solstice Components:**

* Added the Solstice components stylesheet and JavaScript loader from the CDN to the project’s base HTML template (`layouts/_default/baseof.html`). This enables the use of Solstice web components across the site.

**Enhancements to the Articles Page:**

* Embedded the `efsc-collection`, `efsc-event-filters`, `efsc-event-list`, and `efsc-pagination` components into the `content/articles.md` page. This adds dynamic event filtering, listing, and pagination functionality to the articles section.